### PR TITLE
feat: expose paste option metadata and surface stats in viewer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-target-
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -58,6 +69,18 @@ jobs:
 
       - name: Run test suite (nextest)
         run: cargo nextest run --workspace --all-features
+
+      - name: Frontend lint
+        working-directory: frontend
+        run: npm run lint
+
+      - name: Frontend unit tests
+        working-directory: frontend
+        run: npm test -- --run
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
 
       - name: Coverage (llvm-cov)
         run: |

--- a/frontend/src/server/types.ts
+++ b/frontend/src/server/types.ts
@@ -19,4 +19,23 @@ export interface PasteViewResponse {
       label?: string | null
     }>
   } | null
+  encryption: {
+    algorithm: 'none' | 'aes256_gcm' | 'chacha20_poly1305' | 'xchacha20_poly1305'
+    requiresKey: boolean
+  }
+  timeLock?: {
+    notBefore?: number | null
+    notAfter?: number | null
+  } | null
+  attestation?: {
+    kind: string
+    issuer?: string | null
+  } | null
+  persistence?: {
+    kind: string
+    detail?: string | null
+  } | null
+  webhook?: {
+    provider?: 'slack' | 'teams' | 'generic' | null
+  } | null
 }

--- a/frontend/src/theme/__tests__/themeStorage.test.ts
+++ b/frontend/src/theme/__tests__/themeStorage.test.ts
@@ -19,6 +19,15 @@ afterEach(() => {
 
 describe('getInitialTheme', () => {
   it('defaults to light when window is undefined', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: originalMatchMedia,
+      writable: true,
+    })
+    Object.defineProperty(window, 'localStorage', {
+      value: originalLocalStorage,
+      writable: true,
+    })
+
     expect(getInitialTheme()).toBe('light')
   })
 

--- a/src/server/models.rs
+++ b/src/server/models.rs
@@ -29,6 +29,54 @@ pub struct PasteViewResponse {
     pub expires_at: Option<i64>,
     pub burn_after_reading: bool,
     pub bundle: Option<BundleMetadata>,
+    pub encryption: PasteEncryptionInfo,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time_lock: Option<PasteTimeLockInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attestation: Option<PasteAttestationInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persistence: Option<PastePersistenceInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub webhook: Option<PasteWebhookInfo>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PasteEncryptionInfo {
+    pub algorithm: EncryptionAlgorithm,
+    pub requires_key: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PasteTimeLockInfo {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_before: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_after: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PasteAttestationInfo {
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issuer: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PastePersistenceInfo {
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PasteWebhookInfo {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<WebhookProvider>,
 }
 
 #[derive(Deserialize, Default, Clone)]


### PR DESCRIPTION
- extend PasteViewResponse with encryption, attestation, time-lock, persistence, and webhook summaries
- render a paste options panel in the SPA and tighten response typing
- refresh README with SPA workflow guidance and expand CI to run frontend lint/test/build
- harden run_both workflow by fixing metadata handling and tests