### PR TITLE
fix: CI — fly.toml concurrency syntax + Dockerfile scripts copy order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 FROM node:20-slim AS frontend
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
+COPY frontend/scripts/ ./scripts/
 RUN npm ci --prefer-offline
 COPY frontend/ ./
 RUN npm run build

--- a/fly.toml
+++ b/fly.toml
@@ -41,7 +41,7 @@ primary_region = 'iad'
     protocol = "http"
     restart_limit = 3
 
-  [[services.concurrency]]
+  [services.concurrency]
     type = "connections"
     soft_limit = 200
     hard_limit = 250


### PR DESCRIPTION
## Summary
- **fly.toml**: `[[services.concurrency]]` (array-of-tables) → `[services.concurrency]` (table) — `flyctl config validate` was failing with `Unknown type for service concurrency: []interface {}`
- **Dockerfile**: add `COPY frontend/scripts/ ./scripts/` before `npm ci` — the `prepare` script in package.json runs `node ./scripts/install_playwright.js` but that file wasn't available during `npm ci` in the Docker build stage

## Test plan
- [ ] Fly.io deploy workflow passes `flyctl config validate`
- [ ] Docker publish workflow completes `npm ci` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)