### PR TITLE
fix: auth.ts TypeScript errors — partializeAuthState type + login privkey annotation

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -33,10 +33,7 @@ export type KeyFormat = "hex" | "base64" | "pem" | "raw";
 
 // Exported for testing — strips privkey from the persisted state so it is
 // never written to localStorage.
-export const partializeAuthState = (state: {
-  user: User | null;
-  token: string | null;
-}) => ({
+export const partializeAuthState = (state: AuthState) => ({
   user: state.user
     ? {
         pubkeyHash: state.user.pubkeyHash,
@@ -202,7 +199,7 @@ export const useAuth = create<AuthState>()(
         }
       },
 
-      login: async (privkey) => {
+      login: async (privkey?: string) => {
         set({ isLoading: true });
         try {
           // Check for HTTPS in production


### PR DESCRIPTION
Fixes TypeScript compilation errors introduced in #422 (issue #377 frontend security fix).

-  typed to accept `AuthState` instead of narrow `{ user, token }` — fixes TS2345 persist StateCreator mismatch
- `login: async (privkey?: string)` explicit annotation — fixes TS7006 implicit any
- Both `set({ isLoading })` call sites now type-check correctly

`tsc --noEmit` passes cleanly.