### PR TITLE
fix: auth.test.ts TypeScript — cast partial objects to AuthState

### DIFF
--- a/frontend/src/stores/__tests__/auth.test.ts
+++ b/frontend/src/stores/__tests__/auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { partializeAuthState } from "../auth";
-import type { User } from "../auth";
+import type { AuthState, User } from "../auth";
 
 const mockUser: User = {
   pubkeyHash: "abc123",
@@ -15,12 +15,12 @@ describe("partializeAuthState", () => {
   });
 
   it("excludes privkey from persisted state", () => {
-    const result = partializeAuthState({ user: mockUser, token: "tok" });
+    const result = partializeAuthState({ user: mockUser, token: "tok" } as AuthState);
     expect(result.user).not.toHaveProperty("privkey");
   });
 
   it("preserves pubkeyHash, pubkey, and createdAt", () => {
-    const result = partializeAuthState({ user: mockUser, token: "tok" });
+    const result = partializeAuthState({ user: mockUser, token: "tok" } as AuthState);
     expect(result.user).toEqual({
       pubkeyHash: "abc123",
       pubkey: "pubkey_base64",
@@ -29,12 +29,12 @@ describe("partializeAuthState", () => {
   });
 
   it("persists token", () => {
-    const result = partializeAuthState({ user: mockUser, token: "my-token" });
+    const result = partializeAuthState({ user: mockUser, token: "my-token" } as AuthState);
     expect(result.token).toBe("my-token");
   });
 
   it("handles null user", () => {
-    const result = partializeAuthState({ user: null, token: null });
+    const result = partializeAuthState({ user: null, token: null } as AuthState);
     expect(result.user).toBeNull();
     expect(result.token).toBeNull();
   });


### PR DESCRIPTION
Follows up #433: test file was passing `{ user, token }` partial objects to `partializeAuthState` which now expects `AuthState`. Cast with `as AuthState` since the function only reads `.user` and `.token` fields.