### PR TITLE
fix: fly.toml — crypto-verifier memory 128mb → 256mb

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -61,5 +61,5 @@ primary_region = 'iad'
 
 [[vm]]
   size = 'shared-cpu-1x'
-  memory = '128mb'
+  memory = '256mb'
   processes = ["crypto-verifier"]


### PR DESCRIPTION
Fly.io requires memory in 256 MiB increments. The `128mb` setting introduced in #428 caused deploy failures: `invalid config.guest.memory_mb, must be in 256 MiB increment`.