### PR TITLE
fix: add lock file to agent.sh to prevent concurrent rogue runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ server.log
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .agent-logs/
+.agent.lock
 .claude/*.lock

--- a/scripts/agent.sh
+++ b/scripts/agent.sh
@@ -31,6 +31,22 @@ mkdir -p "$LOG_DIR"
 
 trap 'rm -rf "$PROMPT_DIR"' EXIT
 
+# Lock file — prevent concurrent agent runs (e.g. from rogue background sessions)
+LOCK_FILE="${REPO_ROOT}/.agent.lock"
+if ! ( set -o noclobber; echo "$$" > "$LOCK_FILE" ) 2>/dev/null; then
+  existing_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "unknown")
+  # Stale lock: if existing PID is not a running process, remove and proceed
+  if [[ "$existing_pid" != "unknown" ]] && ! kill -0 "$existing_pid" 2>/dev/null; then
+    echo "Removing stale lock for dead PID ${existing_pid}."
+    rm -f "$LOCK_FILE"
+    echo "$$" > "$LOCK_FILE"
+  else
+    echo "Agent already running (PID ${existing_pid}). Exiting to avoid concurrent runs."
+    exit 0
+  fi
+fi
+trap 'rm -rf "$PROMPT_DIR"; rm -f "$LOCK_FILE"' EXIT
+
 # Parse args
 if [[ "${1:-}" == "--loop" ]]; then
   LOOP_MODE=true


### PR DESCRIPTION
## Summary
- Adds PID-based `.agent.lock` at `agent.sh` startup — concurrent invocations exit immediately
- Stale-lock detection: if the owning PID is dead, removes stale lock and proceeds
- Gitignores `.agent.lock` so it never gets committed

## Why
The `copy-research` Claude session (PID 79320) repeatedly spawns `bash ./scripts/agent.sh` as background tasks via zsh shell snapshots. These rogue agents switch git HEAD mid-implementation, causing commits to land on wrong branches and corrupting the main agent's working tree.

## Test plan
- [ ] Start agent.sh in one terminal — `.agent.lock` appears with that PID
- [ ] Start agent.sh in a second terminal — it prints "Agent already running" and exits 0
- [ ] Kill the first agent — lock file is removed by EXIT trap
- [ ] Start agent.sh again — acquires lock cleanly (stale-lock path not needed)
- [ ] Manually create stale lock with dead PID — new start detects stale, removes, proceeds