### PR TITLE
fix: bug: KyberHybridAes256Gcm uses SHA-256 simulation instead of real KEM — zero post-quantum security (pqc_kyber 0.7 also pre-FIPS 203)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,14 +665,15 @@ dependencies = [
  "ed25519-dalek",
  "env_logger",
  "hex",
+ "hkdf",
  "hmac",
  "html-escape",
  "httpmock",
  "image",
  "log",
+ "ml-kem",
  "nanoid",
  "once_cell",
- "pqc_kyber",
  "pulldown-cmark",
  "rand 0.8.5",
  "regex",
@@ -1305,6 +1306,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1433,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1734,6 +1753,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,6 +1941,19 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "rand_core 0.6.4",
+ "sha3",
+ "zeroize",
 ]
 
 [[package]]
@@ -2196,15 +2247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "pqc_kyber"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b23e1823e8a78ad67990c5cb843d5eba75ab3b8a44d041f3814fde89463dc6f"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2822,6 +2864,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ html-escape = "0.2"
 rand = "0.8"
 aes-gcm = { version = "0.10", features = ["aes"] }
 chacha20poly1305 = "0.10"
-pqc_kyber = "0.7"
+ml-kem = { version = "0.2.3", features = ["deterministic", "zeroize"] }
+hkdf = "0.12"
 sha2 = "0.10"
 base64 = "0.21"
 image = { version = "0.24", default-features = false, features = ["png", "bmp"] }

--- a/src/server/crypto.rs
+++ b/src/server/crypto.rs
@@ -5,13 +5,15 @@ use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
 use chacha20poly1305::{ChaCha20Poly1305, Nonce as ChaNonce, XChaCha20Poly1305, XNonce};
 use rand::rngs::OsRng;
+use rand::RngCore;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::convert::TryInto;
 use zeroize::Zeroizing;
 
-// Real Kyber imports
-use pqc_kyber::*;
+use hkdf::Hkdf;
+use ml_kem::kem::{Decapsulate, Encapsulate};
+use ml_kem::{Ciphertext, KemCore, MlKem768, B32};
 
 use crate::{EncryptionAlgorithm, StoredContent};
 
@@ -162,72 +164,58 @@ fn encrypt_content_sync(
             ))
         }
         EncryptionAlgorithm::KyberHybridAes256Gcm => {
-            // NOTE: Currently using simulation - Real Kyber KEM implementation pending
-            // TODO: Replace with actual pqc_kyber crate when API issues are resolved
+            // Derive a deterministic ML-KEM-768 keypair from the passphrase using HKDF.
+            // The passphrase acts as a static identity: the same passphrase always re-derives
+            // the same (dk, ek) pair.  Fresh OS randomness in `ek.encapsulate` ensures each
+            // call produces a distinct (kem_ct, shared_secret), preserving IND-CPA security.
+            let hk = Hkdf::<Sha256>::new(None, key.as_bytes());
+            let mut d_bytes = [0u8; 32];
+            let mut z_bytes = [0u8; 32];
+            hk.expand(b"ml-kem-768-keygen-d", &mut d_bytes)
+                .map_err(|e| format!("HKDF expand error (d): {}", e))?;
+            hk.expand(b"ml-kem-768-keygen-z", &mut z_bytes)
+                .map_err(|e| format!("HKDF expand error (z): {}", e))?;
+            let d: B32 = d_bytes.into();
+            let z: B32 = z_bytes.into();
+            let (_, ek) = MlKem768::generate_deterministic(&d, &z);
 
-            // Generate a simulated PQ public key (32 bytes)
-            // NOTE: The private/decapsulation key is not stored. It is re-derived from the
-            // passphrase at decryption time.
-            let mut pq_public_key = [0u8; 32];
-            // Use deterministic key generation based on the user key for testing
-            let mut key_hasher = Sha256::new();
-            key_hasher.update(b"pq_public_key");
-            key_hasher.update(key.as_bytes());
-            let hash = key_hasher.finalize();
-            pq_public_key.copy_from_slice(&hash[..32]);
+            // Encapsulate using OsRng — `encapsulate(&mut OsRng)` passes OS entropy as the
+            // ephemeral `m` value (FIPS 203 §6.2), so two encryptions with the same passphrase
+            // produce computationally unlinkable (kem_ct, shared_secret) pairs.
+            let (kem_ct, shared_secret) = ek
+                .encapsulate(&mut OsRng)
+                .map_err(|_| "ML-KEM-768 encapsulation failed".to_string())?;
 
-            // Simulate PQ KEM encapsulation - use deterministic values
-            let mut kem_shared_secret = Zeroizing::new([0u8; 32]);
-            let mut kem_ciphertext = [0u8; 64];
-            let mut secret_hasher = Sha256::new();
-            secret_hasher.update(b"kem_shared_secret");
-            secret_hasher.update(key.as_bytes());
-            kem_shared_secret.copy_from_slice(&secret_hasher.finalize()[..32]);
+            // Derive AES-256-GCM key from the KEM shared secret via HKDF.
+            let hk2 = Hkdf::<Sha256>::new(None, &shared_secret);
+            let mut aes_key = Zeroizing::new([0u8; 32]);
+            hk2.expand(b"aes-256-gcm-key", &mut *aes_key)
+                .map_err(|e| format!("HKDF expand error (aes-key): {}", e))?;
 
-            let mut cipher_hasher = Sha256::new();
-            cipher_hasher.update(b"kem_ciphertext");
-            cipher_hasher.update(key.as_bytes());
-            let hash = cipher_hasher.finalize();
-            kem_ciphertext[..32].copy_from_slice(&hash);
-            kem_ciphertext[32..].copy_from_slice(&hash);
-
-            // Generate AES nonce
-            let mut nonce_bytes = [0u8; 12];
-            OsRng.fill_bytes(&mut nonce_bytes);
-
-            // Use Kyber shared secret directly with user passphrase for additional security
-            let mut hasher = Sha256::new();
-            hasher.update(*kem_shared_secret);
-            hasher.update(key.as_bytes());
-            let aes_key: Zeroizing<[u8; 32]> = Zeroizing::new(hasher.finalize().into());
-
-            // Encrypt with AES-GCM using the hybrid-derived key
             let cipher = Aes256Gcm::new_from_slice(&*aes_key)
                 .map_err(|_| "failed to initialise AES cipher".to_string())?;
+            let mut nonce_bytes = [0u8; 12];
+            OsRng.fill_bytes(&mut nonce_bytes);
             let nonce = AesNonce::from(nonce_bytes);
-
-            let ciphertext_aes = cipher
+            let aes_ciphertext = cipher
                 .encrypt(&nonce, text.as_bytes())
                 .map_err(|_| "failed to encrypt content with AES".to_string())?;
 
-            // Store hybrid data: PQ_ciphertext|PQ_public_key|aes_ciphertext|aes_nonce
-            // NOTE: The private key is NOT stored. It is re-derived from the passphrase on
-            // decryption. Storing the decapsulation key alongside the ciphertext would allow
-            // any server-side reader to decrypt without knowing the passphrase.
-            let pq_ciphertext_b64 = BASE64_STANDARD.encode(kem_ciphertext);
-            let pq_public_key_b64 = BASE64_STANDARD.encode(pq_public_key);
-            let aes_ciphertext_b64 = BASE64_STANDARD.encode(ciphertext_aes);
-            let aes_nonce_b64 = BASE64_STANDARD.encode(nonce_bytes);
-
-            let combined_ciphertext = format!(
-                "{}|{}|{}|{}",
-                pq_ciphertext_b64, pq_public_key_b64, aes_ciphertext_b64, aes_nonce_b64,
+            // 3-part storage format (new ML-KEM-768, distinct from legacy 4/5-part blobs):
+            //   kem_ct_b64 | aes_ct_b64 | aes_nonce_b64
+            // The decapsulation key is NOT stored; it is re-derived from the passphrase on
+            // decryption, so server-side access to the blob cannot decrypt the content.
+            let combined = format!(
+                "{}|{}|{}",
+                BASE64_STANDARD.encode(&*kem_ct),
+                BASE64_STANDARD.encode(&aes_ciphertext),
+                BASE64_STANDARD.encode(nonce_bytes),
             );
 
             Ok((
                 StoredContent::Encrypted {
                     algorithm,
-                    ciphertext: combined_ciphertext,
+                    ciphertext: combined,
                     nonce: String::new(),
                     salt: String::new(),
                 },
@@ -290,120 +278,102 @@ pub fn decrypt_content(content: &StoredContent, key: Option<&str>) -> Result<Str
             let extracted_key = key.ok_or(DecryptError::MissingKey)?;
             log::info!("Starting decryption for algorithm: {:?}", algorithm);
 
-            // Handle Kyber algorithm first - it doesn't use base64 encoding for storage
+            // KyberHybridAes256Gcm uses a different storage layout; handle it separately.
             if matches!(algorithm, EncryptionAlgorithm::KyberHybridAes256Gcm) {
-                // Kyber hybrid uses a different storage format, bypass normal decryption
                 let key_str = extracted_key;
+                let parts: Vec<&str> = ciphertext.split('|').collect();
 
-                log::info!(
-                    "Starting Kyber decryption for key length: {}",
-                    key_str.len()
-                );
+                match parts.len() {
+                    3 => {
+                        // New ML-KEM-768 format: kem_ct_b64|aes_ct_b64|aes_nonce_b64
+                        let hk = Hkdf::<Sha256>::new(None, key_str.as_bytes());
+                        let mut d_bytes = [0u8; 32];
+                        let mut z_bytes = [0u8; 32];
+                        hk.expand(b"ml-kem-768-keygen-d", &mut d_bytes)
+                            .map_err(|_| DecryptError::InvalidKey)?;
+                        hk.expand(b"ml-kem-768-keygen-z", &mut z_bytes)
+                            .map_err(|_| DecryptError::InvalidKey)?;
+                        let d: B32 = d_bytes.into();
+                        let z: B32 = z_bytes.into();
+                        let (dk, _) = MlKem768::generate_deterministic(&d, &z);
 
-                // For Kyber, ciphertext is stored as the combined string directly (not base64 encoded)
-                // New format (4 parts): PQ_ciphertext|PQ_public_key|aes_ciphertext|aes_nonce
-                // Legacy format (5 parts): PQ_ciphertext|PQ_public_key|aes_ciphertext|aes_nonce|PQ_private_key
-                // The 5th component (private key) in legacy blobs is ignored; the key is always
-                // re-derived from the passphrase.
-                let ciphertext_str = ciphertext; // Use the stored string directly
-                log::debug!("Ciphertext string length: {}", ciphertext_str.len());
+                        let kem_ct_bytes = BASE64_STANDARD
+                            .decode(parts[0])
+                            .map_err(|_| DecryptError::InvalidKey)?;
+                        // ML-KEM-768 ciphertext is exactly 1088 bytes.
+                        let kem_ct_arr: [u8; 1088] = kem_ct_bytes
+                            .try_into()
+                            .map_err(|_| DecryptError::InvalidKey)?;
+                        let kem_ct: Ciphertext<MlKem768> = kem_ct_arr.into();
 
-                let parts: Vec<&str> = ciphertext_str.split('|').collect();
-                log::debug!("Parsed {} parts from ciphertext", parts.len());
+                        let shared_secret = dk
+                            .decapsulate(&kem_ct)
+                            .map_err(|_| DecryptError::InvalidKey)?;
 
-                if parts.len() != 4 && parts.len() != 5 {
-                    log::error!(
-                        "Expected 4 or 5 parts in Kyber ciphertext, got {}",
-                        parts.len()
-                    );
-                    return Err(DecryptError::InvalidKey);
+                        let hk2 = Hkdf::<Sha256>::new(None, &shared_secret);
+                        let mut aes_key = Zeroizing::new([0u8; 32]);
+                        hk2.expand(b"aes-256-gcm-key", &mut *aes_key)
+                            .map_err(|_| DecryptError::InvalidKey)?;
+
+                        let aes_ciphertext = BASE64_STANDARD
+                            .decode(parts[1])
+                            .map_err(|_| DecryptError::InvalidKey)?;
+                        let aes_nonce_bytes = BASE64_STANDARD
+                            .decode(parts[2])
+                            .map_err(|_| DecryptError::InvalidKey)?;
+
+                        let cipher = Aes256Gcm::new_from_slice(&*aes_key)
+                            .map_err(|_| DecryptError::InvalidKey)?;
+                        let nonce_arr: [u8; 12] = aes_nonce_bytes
+                            .try_into()
+                            .map_err(|_| DecryptError::InvalidKey)?;
+                        let nonce = AesNonce::from(nonce_arr);
+
+                        return cipher
+                            .decrypt(&nonce, aes_ciphertext.as_ref())
+                            .map_err(|_| DecryptError::InvalidKey)
+                            .and_then(|bytes| {
+                                String::from_utf8(bytes).map_err(|_| DecryptError::InvalidKey)
+                            });
+                    }
+                    4 | 5 => {
+                        // Legacy simulation format (4 or 5 parts):
+                        //   pq_ct_b64 | pub_key_b64 | aes_ct_b64 | aes_nonce_b64 [| ignored]
+                        // Re-derive the SHA-256 simulation shared secret for backward compat.
+                        let aes_ciphertext = BASE64_STANDARD
+                            .decode(parts[2])
+                            .map_err(|_| DecryptError::InvalidKey)?;
+                        let aes_nonce_bytes = BASE64_STANDARD
+                            .decode(parts[3])
+                            .map_err(|_| DecryptError::InvalidKey)?;
+
+                        let mut secret_hasher = Sha256::new();
+                        secret_hasher.update(b"kem_shared_secret");
+                        secret_hasher.update(key_str.as_bytes());
+                        let shared_secret: [u8; 32] = secret_hasher.finalize().into();
+
+                        let mut key_hasher = Sha256::new();
+                        key_hasher.update(shared_secret);
+                        key_hasher.update(key_str.as_bytes());
+                        let aes_key: Zeroizing<[u8; 32]> =
+                            Zeroizing::new(key_hasher.finalize().into());
+
+                        let cipher = Aes256Gcm::new_from_slice(&*aes_key)
+                            .map_err(|_| DecryptError::InvalidKey)?;
+                        let nonce_arr: [u8; 12] = aes_nonce_bytes
+                            .try_into()
+                            .map_err(|_| DecryptError::InvalidKey)?;
+                        let nonce = AesNonce::from(nonce_arr);
+
+                        return cipher
+                            .decrypt(&nonce, aes_ciphertext.as_ref())
+                            .map_err(|_| DecryptError::InvalidKey)
+                            .and_then(|bytes| {
+                                String::from_utf8(bytes).map_err(|_| DecryptError::InvalidKey)
+                            });
+                    }
+                    _ => return Err(DecryptError::InvalidKey),
                 }
-
-                let pq_ciphertext_b64 = parts[0];
-                let pq_public_key_b64 = parts[1];
-                let aes_ciphertext_b64 = parts[2];
-                let aes_nonce_b64 = parts[3];
-                // parts[4] (legacy private key) is intentionally ignored — always re-derive.
-
-                log::debug!("AES ciphertext b64 length: {}", aes_ciphertext_b64.len());
-                log::debug!("AES nonce b64 length: {}", aes_nonce_b64.len());
-
-                // Decode PQ components first
-                let _pq_ciphertext = general_purpose::STANDARD
-                    .decode(pq_ciphertext_b64)
-                    .map_err(|e| {
-                        log::error!("Failed to decode PQ ciphertext: {}", e);
-                        DecryptError::InvalidKey
-                    })?;
-
-                let _pq_public_key = general_purpose::STANDARD
-                    .decode(pq_public_key_b64)
-                    .map_err(|e| {
-                        log::error!("Failed to decode PQ public key: {}", e);
-                        DecryptError::InvalidKey
-                    })?;
-
-                // Decode AES components
-                let aes_ciphertext = general_purpose::STANDARD
-                    .decode(aes_ciphertext_b64)
-                    .map_err(|e| {
-                        log::error!("Failed to decode AES ciphertext: {}", e);
-                        DecryptError::InvalidKey
-                    })?;
-                let aes_nonce = general_purpose::STANDARD
-                    .decode(aes_nonce_b64)
-                    .map_err(|e| {
-                        log::error!("Failed to decode AES nonce: {}", e);
-                        DecryptError::InvalidKey
-                    })?;
-                log::debug!(
-                    "Decoded components - AES ciphertext: {} bytes, nonce: {} bytes",
-                    aes_ciphertext.len(),
-                    aes_nonce.len()
-                );
-
-                // Simulate PQ KEM decapsulation (same deterministic approach as encryption)
-                let mut shared_secret = Zeroizing::new([0u8; 32]);
-                let mut secret_hasher = Sha256::new();
-                secret_hasher.update(b"kem_shared_secret");
-                secret_hasher.update(key_str.as_bytes());
-                shared_secret.copy_from_slice(&secret_hasher.finalize()[..32]);
-
-                log::debug!("Generated shared secret using deterministic simulation");
-
-                // Recreate the AES key (same as encryption)
-                let mut key_hasher = Sha256::new();
-                key_hasher.update(*shared_secret);
-                key_hasher.update(key_str.as_bytes());
-                let aes_key: Zeroizing<[u8; 32]> = Zeroizing::new(key_hasher.finalize().into());
-
-                log::debug!("Generated AES key");
-
-                // Decrypt with AES-GCM
-                let cipher = Aes256Gcm::new_from_slice(&*aes_key).map_err(|e| {
-                    log::error!("Failed to create AES cipher: {:?}", e);
-                    DecryptError::InvalidKey
-                })?;
-                let nonce_array: [u8; 12] = aes_nonce.clone().try_into().map_err(|_| {
-                    log::error!("Invalid nonce length: {}, expected 12", aes_nonce.len());
-                    DecryptError::InvalidKey
-                })?;
-                let nonce = AesNonce::from(nonce_array);
-
-                log::debug!("Starting AES decryption");
-
-                return cipher
-                    .decrypt(&nonce, aes_ciphertext.as_ref())
-                    .map_err(|e| {
-                        log::error!("AES decryption failed: {:?}", e);
-                        DecryptError::InvalidKey
-                    })
-                    .and_then(|bytes| {
-                        String::from_utf8(bytes).map_err(|e| {
-                            log::error!("UTF-8 conversion failed: {:?}", e);
-                            DecryptError::InvalidKey
-                        })
-                    });
             }
 
             // Normal algorithms that use base64 encoding

--- a/tests/crypto_tests.rs
+++ b/tests/crypto_tests.rs
@@ -258,8 +258,8 @@ async fn decrypt_truncated_ciphertext_aes_gcm_returns_invalid_key() {
     );
 }
 
-/// Verify that the Kyber ciphertext no longer contains the private key as the 5th component.
-/// The stored blob must have exactly 4 pipe-delimited parts.
+/// Verify the new ML-KEM-768 blob uses exactly 3 pipe-delimited parts.
+/// No private key is stored; it is re-derived from the passphrase at decryption time.
 #[tokio::test]
 async fn kyber_ciphertext_does_not_contain_private_key() {
     let plaintext = "private key must not be stored";
@@ -281,46 +281,149 @@ async fn kyber_ciphertext_does_not_contain_private_key() {
     let parts: Vec<&str> = ciphertext.split('|').collect();
     assert_eq!(
         parts.len(),
-        4,
-        "Kyber ciphertext must have exactly 4 parts (no private key stored): got {}",
+        3,
+        "ML-KEM-768 ciphertext must have exactly 3 parts (kem_ct|aes_ct|nonce): got {}",
         parts.len()
     );
 }
 
-/// Verify that legacy 5-part Kyber blobs (with the private key embedded) can still be
-/// decrypted — the 5th component is ignored and the key is re-derived from the passphrase.
-#[tokio::test]
-async fn kyber_legacy_5part_blob_decrypts_successfully() {
-    let key = "kyber-legacy-key-1234567890123456789";
+/// Verify that legacy simulation blobs (the old SHA-256-based 4-part and 5-part formats
+/// produced before ML-KEM-768 was implemented) can still be decrypted.
+#[test]
+fn kyber_legacy_simulation_blob_decrypts_successfully() {
+    use aes_gcm::aead::{Aead, KeyInit};
+    use aes_gcm::{Aes256Gcm, Nonce as AesNonce};
+    use base64::engine::general_purpose::STANDARD as B64;
+    use sha2::{Digest, Sha256};
 
-    // Build a fresh 4-part blob, then manually append a (bogus) 5th component to simulate
-    // a pre-fix legacy record. Decryption must succeed and ignore the extra component.
+    let key = "kyber-legacy-key-1234567890123456789";
+    let plaintext = "legacy compatibility check";
+
+    // Reproduce the old SHA-256 simulation encrypt logic exactly.
+    let pq_pub_hash = Sha256::new()
+        .chain_update(b"pq_public_key")
+        .chain_update(key.as_bytes())
+        .finalize();
+
+    let sim_secret = Sha256::new()
+        .chain_update(b"kem_shared_secret")
+        .chain_update(key.as_bytes())
+        .finalize();
+
+    let ct_hash = Sha256::new()
+        .chain_update(b"kem_ciphertext")
+        .chain_update(key.as_bytes())
+        .finalize();
+    let mut kem_ciphertext = [0u8; 64];
+    kem_ciphertext[..32].copy_from_slice(&ct_hash);
+    kem_ciphertext[32..].copy_from_slice(&ct_hash);
+
+    // Use a fixed nonce so the test is deterministic.
+    let nonce_bytes = [0x55u8; 12];
+
+    let aes_key_bytes: [u8; 32] = Sha256::new()
+        .chain_update(sim_secret)
+        .chain_update(key.as_bytes())
+        .finalize()
+        .into();
+
+    let cipher = Aes256Gcm::new_from_slice(&aes_key_bytes).unwrap();
+    let nonce = AesNonce::from(nonce_bytes);
+    let aes_ciphertext = cipher.encrypt(&nonce, plaintext.as_bytes()).unwrap();
+
+    let legacy_4part = format!(
+        "{}|{}|{}|{}",
+        B64.encode(kem_ciphertext),
+        B64.encode(&pq_pub_hash[..32]),
+        B64.encode(&aes_ciphertext),
+        B64.encode(nonce_bytes),
+    );
+
+    // 4-part legacy blob must decrypt.
+    let stored_4 = StoredContent::Encrypted {
+        algorithm: EncryptionAlgorithm::KyberHybridAes256Gcm,
+        ciphertext: legacy_4part.clone(),
+        nonce: String::new(),
+        salt: String::new(),
+    };
+    let decrypted = decrypt_content(&stored_4, Some(key))
+        .expect("legacy 4-part simulation blob must still decrypt");
+    assert_eq!(decrypted, plaintext);
+
+    // 5-part legacy blob (with trailing ignored component) must also decrypt.
+    let legacy_5part = format!("{}|ZmFrZXByaXZhdGVrZXk=", legacy_4part);
+    let stored_5 = StoredContent::Encrypted {
+        algorithm: EncryptionAlgorithm::KyberHybridAes256Gcm,
+        ciphertext: legacy_5part,
+        nonce: String::new(),
+        salt: String::new(),
+    };
+    let decrypted5 = decrypt_content(&stored_5, Some(key))
+        .expect("legacy 5-part simulation blob must still decrypt");
+    assert_eq!(decrypted5, plaintext);
+}
+
+/// Decrypting a ML-KEM-768 blob with the wrong passphrase must return an error.
+#[tokio::test]
+async fn decrypt_wrong_key_kyber_returns_invalid_key() {
+    let plaintext = "secret kyber data";
+    let correct_key = "correct-kyber-key-123456789012345678901";
+
     let encrypted = copypaste::server::crypto::encrypt_content(
-        "legacy compatibility check",
-        key,
-        copypaste::EncryptionAlgorithm::KyberHybridAes256Gcm,
+        plaintext,
+        correct_key,
+        EncryptionAlgorithm::KyberHybridAes256Gcm,
     )
     .await
     .expect("encryption should succeed");
 
-    let ciphertext_4part = match encrypted {
-        copypaste::StoredContent::Encrypted { ciphertext, .. } => ciphertext,
-        _ => panic!("expected encrypted content"),
+    let result = decrypt_content(
+        &encrypted,
+        Some("wrong-kyber-key-XXXXXXXXXXXXXXXXXXXXXXXXX"),
+    );
+    assert!(result.is_err(), "decryption with wrong key must fail");
+}
+
+/// Two ML-KEM-768 encryptions of the same plaintext with the same passphrase must
+/// produce different KEM ciphertexts, proving that `encapsulate` uses OS randomness.
+#[tokio::test]
+async fn kyber_same_passphrase_produces_different_kem_ciphertext() {
+    let plaintext = "randomness check";
+    let key = "rand-check-key-123456789012345678901234";
+
+    let enc1 = copypaste::server::crypto::encrypt_content(
+        plaintext,
+        key,
+        EncryptionAlgorithm::KyberHybridAes256Gcm,
+    )
+    .await
+    .expect("first encryption should succeed");
+
+    let enc2 = copypaste::server::crypto::encrypt_content(
+        plaintext,
+        key,
+        EncryptionAlgorithm::KyberHybridAes256Gcm,
+    )
+    .await
+    .expect("second encryption should succeed");
+
+    let ct1 = match &enc1 {
+        StoredContent::Encrypted { ciphertext, .. } => {
+            ciphertext.split('|').next().unwrap().to_string()
+        }
+        _ => panic!("expected encrypted"),
+    };
+    let ct2 = match &enc2 {
+        StoredContent::Encrypted { ciphertext, .. } => {
+            ciphertext.split('|').next().unwrap().to_string()
+        }
+        _ => panic!("expected encrypted"),
     };
 
-    // Append a fake 5th component (as the legacy format did)
-    let legacy_ciphertext = format!("{}|ZmFrZXByaXZhdGVrZXk=", ciphertext_4part);
-
-    let legacy_stored = copypaste::StoredContent::Encrypted {
-        algorithm: copypaste::EncryptionAlgorithm::KyberHybridAes256Gcm,
-        ciphertext: legacy_ciphertext,
-        nonce: String::new(),
-        salt: String::new(),
-    };
-
-    let decrypted = copypaste::server::crypto::decrypt_content(&legacy_stored, Some(key))
-        .expect("legacy 5-part Kyber blob must still decrypt");
-    assert_eq!(decrypted, "legacy compatibility check");
+    assert_ne!(
+        ct1, ct2,
+        "KEM ciphertexts must differ across encryptions (OsRng must be used)"
+    );
 }
 
 // OCaml verification behaviour tests


### PR DESCRIPTION
## Closes #340

## What changed
Implementation for: bug: KyberHybridAes256Gcm uses SHA-256 simulation instead of real KEM — zero post-quantum security (pqc_kyber 0.7 also pre-FIPS 203)

## Approach
Attempt 2/5

## Testing
All local validation passed. Agent review: approved.