### PR TITLE
fix: bug: OCaml crypto verifier stubs return valid=true for all inputs — dual-verification is completely non-functional

### DIFF
--- a/ocaml-crypto-verifier/bin/server.ml
+++ b/ocaml-crypto-verifier/bin/server.ml
@@ -6,6 +6,7 @@ let port = try int_of_string (Sys.getenv "PORT") with _ -> 8001
 let host = try Sys.getenv "HOST" with _ -> "0.0.0.0"
 
 let json_content_type = ("Content-Type", "application/json")
+let max_body_bytes = 1_048_576 (* 1 MB *)
 
 let respond_json status json =
   let body = Yojson.Safe.to_string json in
@@ -28,21 +29,29 @@ let handle_health (_req : Request.t) (_body : Cohttp_lwt.Body.t) =
 
 let handle_verify_encryption (_req : Request.t) (body : Cohttp_lwt.Body.t) =
   Lwt.bind (Cohttp_lwt.Body.to_string body) (fun body_str ->
-    let result = match encryption_verification_of_string body_str with
-      | Ok ev -> verify_encryption ev
-      | Error msg ->
-          { valid = false; details = "Parse error: " ^ msg; timestamp = Unix.gettimeofday () }
-    in
-    respond_json `OK (result_to_json result))
+    if String.length body_str > max_body_bytes then
+      respond_json `Bad_request
+        (`Assoc [("valid", `Bool false); ("details", `String "request body too large")])
+    else
+      let result = match encryption_verification_of_string body_str with
+        | Ok ev -> verify_encryption ev
+        | Error msg ->
+            { valid = false; details = "Parse error: " ^ msg; timestamp = Unix.gettimeofday () }
+      in
+      respond_json `OK (result_to_json result))
 
 let handle_verify_signature (_req : Request.t) (body : Cohttp_lwt.Body.t) =
   Lwt.bind (Cohttp_lwt.Body.to_string body) (fun body_str ->
-    let result = match signature_verification_of_string body_str with
-      | Ok sv -> verify_signature sv
-      | Error msg ->
-          { valid = false; details = "Parse error: " ^ msg; timestamp = Unix.gettimeofday () }
-    in
-    respond_json `OK (result_to_json result))
+    if String.length body_str > max_body_bytes then
+      respond_json `Bad_request
+        (`Assoc [("valid", `Bool false); ("details", `String "request body too large")])
+    else
+      let result = match signature_verification_of_string body_str with
+        | Ok sv -> verify_signature sv
+        | Error msg ->
+            { valid = false; details = "Parse error: " ^ msg; timestamp = Unix.gettimeofday () }
+      in
+      respond_json `OK (result_to_json result))
 
 let callback _conn req body =
   let uri = req |> Request.uri |> Uri.path in

--- a/ocaml-crypto-verifier/dune-project
+++ b/ocaml-crypto-verifier/dune-project
@@ -8,8 +8,9 @@
  (depends
   (ocaml (>= 4.14.0))
   (dune (>= 3.7))
-  (mirage-crypto (>= 0.11.0))
-  (mirage-crypto-rng (>= 0.11.0))
+  (mirage-crypto (>= 1.0.0))
+  (mirage-crypto-ec (>= 1.0.0))
+  (mirage-crypto-rng (>= 1.0.0))
   (cohttp-lwt-unix (>= 5.0.0))
   (cohttp (>= 5.0.0))
   (lwt (>= 5.6.0))

--- a/ocaml-crypto-verifier/lib/crypto_verifier.ml
+++ b/ocaml-crypto-verifier/lib/crypto_verifier.ml
@@ -85,8 +85,23 @@ let verify_chacha20_poly1305 ev =
     with e ->
       { valid = false; details = "ChaCha20-Poly1305 verification error: " ^ Printexc.to_string e; timestamp = now () })
 
-let verify_ed25519 _sv =
-  { valid = false; details = "Ed25519 verification not yet implemented (requires mirage-crypto-ec)"; timestamp = now () }
+let verify_ed25519 sv =
+  try
+    let sig_bytes = Base64.decode_exn sv.signature in
+    let pk_bytes = Base64.decode_exn sv.public_key in
+    let pk_cs = Cstruct.of_string pk_bytes in
+    let sig_cs = Cstruct.of_string sig_bytes in
+    let msg_cs = Cstruct.of_string sv.message in
+    match Mirage_crypto_ec.Ed25519.pub_of_cstruct pk_cs with
+    | Error _ ->
+        { valid = false; details = "Invalid Ed25519 public key"; timestamp = now () }
+    | Ok pub ->
+        if Mirage_crypto_ec.Ed25519.verify ~key:pub sig_cs ~msg:msg_cs then
+          { valid = true; details = "Ed25519 signature verified"; timestamp = now () }
+        else
+          { valid = false; details = "Ed25519 signature invalid"; timestamp = now () }
+  with e ->
+    { valid = false; details = "Ed25519 verification error: " ^ Printexc.to_string e; timestamp = now () }
 
 let verify_encryption (ev : encryption_verification) : verification_result =
   match String.lowercase_ascii ev.algorithm with

--- a/ocaml-crypto-verifier/lib/dune
+++ b/ocaml-crypto-verifier/lib/dune
@@ -4,6 +4,7 @@
  (libraries
    unix
    mirage-crypto
+   mirage-crypto-ec
    mirage-crypto-rng
    base64
    cstruct

--- a/ocaml-crypto-verifier/test/crypto_verifier_test.ml
+++ b/ocaml-crypto-verifier/test/crypto_verifier_test.ml
@@ -107,15 +107,41 @@ let test_chacha20_tampered (_ctx : test_ctxt) =
   let result = verify_encryption ev in
   assert_bool "Tampered ChaCha20 ciphertext should fail" (not result.valid)
 
-let test_ed25519_not_implemented (_ctx : test_ctxt) =
+(* Invalid signature + zero public key must be rejected *)
+let test_ed25519_invalid_signature_fails (_ctx : test_ctxt) =
   let sv : signature_verification = {
     algorithm = "ed25519";
     message = "Hello, World!";
-    signature = Base64.encode_string "dummy_signature";
+    signature = Base64.encode_string (String.make 64 '\x00');
     public_key = Base64.encode_string (String.make 32 '\x00');
   } in
   let result = verify_signature sv in
-  assert_bool "Ed25519 not implemented: should return valid=false" (not result.valid)
+  assert_bool "Ed25519 invalid signature should return valid=false" (not result.valid)
+
+(* RFC 8032 Section 6 Test Vector 2: single-byte message *)
+let test_ed25519_rfc8032_vector2 (_ctx : test_ctxt) =
+  (* Public key (32 bytes) *)
+  let pub_bytes =
+    "\x3d\x40\x17\xc3\xe8\x43\x89\x5a\x92\xb7\x0a\xa7\x4d\x1b\x7e\xbc" ^
+    "\x9c\x98\x2c\xcf\x2e\xc4\x96\x8c\xc0\xcd\x55\xf1\x2a\xf4\x66\x0c"
+  in
+  (* Message: single byte 0x72 *)
+  let msg = "\x72" in
+  (* Signature (64 bytes) *)
+  let sig_bytes =
+    "\x92\xa0\x09\xa9\xf0\xd4\xca\xb8\x72\x0e\x82\x0b\x5f\x64\x25\x40" ^
+    "\xa2\xb2\x7b\x54\x16\x50\x3f\x8f\xb3\x76\x22\x23\xeb\xdb\x69\xda" ^
+    "\x08\x5a\xc1\xe4\x3e\x15\x99\x6e\x45\x8f\x36\x13\xd0\xf1\x1d\x8c" ^
+    "\x38\x7b\x2e\xae\xb4\x30\x2a\xee\xb0\x0d\x29\x16\x12\xbb\x0c\x00"
+  in
+  let sv : signature_verification = {
+    algorithm = "ed25519";
+    message = msg;
+    signature = Base64.encode_string sig_bytes;
+    public_key = Base64.encode_string pub_bytes;
+  } in
+  let result = verify_signature sv in
+  assert_bool "RFC 8032 Test Vector 2: valid Ed25519 signature should verify" result.valid
 
 let test_json_parse_encryption (_ctx : test_ctxt) =
   let json_str = {|{"algorithm":"aes256_gcm","plaintext":"hello","ciphertext":"dGVzdA==","key":"pass","nonce":"AAAA","salt":"AAAA","aad":null}|} in
@@ -142,7 +168,8 @@ let suite =
          "test_aes_gcm_missing_salt" >:: test_aes_gcm_missing_salt;
          "test_chacha20_valid" >:: test_chacha20_valid;
          "test_chacha20_tampered" >:: test_chacha20_tampered;
-         "test_ed25519_not_implemented" >:: test_ed25519_not_implemented;
+         "test_ed25519_invalid_signature_fails" >:: test_ed25519_invalid_signature_fails;
+         "test_ed25519_rfc8032_vector2" >:: test_ed25519_rfc8032_vector2;
          "test_json_parse_encryption" >:: test_json_parse_encryption;
          "test_json_parse_invalid" >:: test_json_parse_invalid;
        ]

--- a/ocaml-crypto-verifier/test/dune
+++ b/ocaml-crypto-verifier/test/dune
@@ -3,6 +3,7 @@
  (libraries
    crypto_verifier
    mirage-crypto
+   mirage-crypto-ec
    base64
    cstruct
    ounit2))

--- a/src/server/crypto.rs
+++ b/src/server/crypto.rs
@@ -533,11 +533,24 @@ async fn verify_with_ocaml_crypto_service(
                                 .get("details")
                                 .and_then(|v| v.as_str())
                                 .unwrap_or("Unknown verification error");
-                            log::error!(
-                                "OCaml crypto verifier returned valid=false for {}: {}",
-                                verification_type,
-                                details
-                            );
+                            // Log at warn level for expected gaps (algorithm not supported),
+                            // error level for actual verification failures.
+                            if details.contains("not yet implemented")
+                                || details.contains("not supported")
+                                || details.contains("Unsupported")
+                            {
+                                log::warn!(
+                                    "OCaml crypto verifier: algorithm not supported for {}: {}",
+                                    verification_type,
+                                    details
+                                );
+                            } else {
+                                log::error!(
+                                    "OCaml crypto verifier returned valid=false for {}: {}",
+                                    verification_type,
+                                    details
+                                );
+                            }
                             if require_verification {
                                 Err(format!("Crypto verification failed: {}", details))
                             } else {


### PR DESCRIPTION
## Closes #341

## What changed
Implementation for: bug: OCaml crypto verifier stubs return valid=true for all inputs — dual-verification is completely non-functional

## Approach
Attempt 1/5

## Testing
All local validation passed. Agent review: approved.