### PR TITLE
fix: constant-time comparison for SharedSecret and TOTP (fixes #203)

### DIFF
--- a/src/server/attestation.rs
+++ b/src/server/attestation.rs
@@ -5,6 +5,7 @@ use hmac::{Hmac, Mac};
 use rocket::serde::{Deserialize, Serialize};
 use sha1::Sha1;
 use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
 
 use super::models::PasteViewQuery;
 
@@ -67,7 +68,7 @@ pub fn verify_attestation(
             hasher.update(provided.as_bytes());
             let digest = hasher.finalize();
             let encoded = base64::engine::general_purpose::STANDARD.encode(digest);
-            if &encoded == hash {
+            if bool::from(encoded.as_bytes().ct_eq(hash.as_bytes())) {
                 AttestationVerdict::Granted
             } else {
                 AttestationVerdict::Prompt { invalid: true }
@@ -166,7 +167,7 @@ fn verify_totp(
             continue;
         };
         if let Some(candidate) = totp_code(&secret_bytes, candidate_counter, digits) {
-            if candidate == sanitized_code {
+            if bool::from(candidate.as_bytes().ct_eq(sanitized_code.as_bytes())) {
                 return true;
             }
         }


### PR DESCRIPTION
## Summary

- Replace `String::eq` (`==`) with `subtle::ConstantTimeEq` for SharedSecret hash comparison and TOTP code comparison
- Prevents timing oracle attack described in #203
- Additionally fixes TOTP code comparison at line 169 (same vulnerability pattern, not mentioned in original issue)

## Changes

| Location | Before | After |
|----------|--------|-------|
| `attestation.rs:70` | `&encoded == hash` | `encoded.as_bytes().ct_eq(hash.as_bytes())` |
| `attestation.rs:169` | `candidate == sanitized_code` | `candidate.as_bytes().ct_eq(sanitized_code.as_bytes())` |

## Why

`String::eq` uses `memcmp` which short-circuits on the first differing byte. An attacker measuring response latency can reconstruct the stored hash character by character.

`subtle::ConstantTimeEq` always compares all bytes regardless of content, eliminating the timing side-channel.

## Testing

- All 16 attestation-related tests pass
- `subtle` is already a dependency — no new deps added
- 2-line change, minimal risk

## Verification

This vulnerability was detected using [ne](https://gitlab.com/Ryujiyasu/ne), a formal verification tool built on [Kani](https://github.com/model-checking/kani) bounded model checking. See [comment on #203](https://github.com/qxlsz/copypaste.fyi/issues/203#issuecomment-4115215384) for the full analysis.

Fixes #203